### PR TITLE
Make external vector type non-opaque

### DIFF
--- a/lib/vector.ex
+++ b/lib/vector.ex
@@ -302,7 +302,8 @@ defmodule Aja.Vector do
   @type index :: integer
   @type value :: term
 
-  @opaque t(value) :: %__MODULE__{__vector__: Raw.t(value)}
+  @opaque raw(value) :: Raw.t(value)
+  @type t(value) :: %__MODULE__{__vector__: raw(value)}
   @enforce_keys [:__vector__]
   defstruct [:__vector__]
 


### PR DESCRIPTION
First of all, thanks for such a wonderful library! Now onto the PR changes:

This PR makes the struct a non-opaque type, and any change to the `%Aja.Vector{__vector__: ...}` a breaking change. However, this allows matching against the type in guards, without dialyzer spitting "Call does not have expected opaque term ..." errors, while maintaining the opaqueness for the inner `raw` type.

This goes in line with [this change on `MapSet`](https://github.com/elixir-lang/elixir/pull/11917/files). For more context on the error, see [this forum post](https://elixirforum.com/t/dialyzer-complaint-about-mapset-member-not-getting-proper-type-as-argument-possible-specs-bug-in-mapset/20780/17).