### PR TITLE
Remove opaque type for Aja.Vector.t/1 for pattern-matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Dev
 
+- Stop using an opaque type for `Aja.Vector.t/1:t` to enable pattern-matching.
+  Rely on documentation instead, like `Aja.OrdMap.t/2:t`. Thanks @MegaRedHand!
+
 ## v0.6.2 (2023-03-10)
 
 ### Enhancements

--- a/lib/enum.ex
+++ b/lib/enum.ex
@@ -32,8 +32,6 @@ defmodule Aja.Enum do
 
   @compile :inline_list_funcs
 
-  @dialyzer :no_opaque
-
   @type index :: integer
   @type value :: any
   @type t(value) :: Aja.Vector.t(value) | [value] | Enumerable.t()

--- a/lib/helpers/enum_helper.ex
+++ b/lib/helpers/enum_helper.ex
@@ -5,8 +5,6 @@ defmodule Aja.EnumHelper do
 
   alias Aja.Vector.Raw, as: RawVector
 
-  @dialyzer :no_opaque
-
   @compile {:inline, try_get_raw_vec_or_list: 1}
   def try_get_raw_vec_or_list(%Aja.Vector{__vector__: vector}), do: vector
   def try_get_raw_vec_or_list(list) when is_list(list), do: list

--- a/lib/ord_map.ex
+++ b/lib/ord_map.ex
@@ -171,8 +171,8 @@ defmodule Aja.OrdMap do
       iex> match?(%Aja.OrdMap{}, Aja.OrdMap.new())
       true
 
-  Note, however, than `Aja.OrdMap` is an [opaque type](https://hexdocs.pm/elixir/typespecs.html#user-defined-types):
-  its struct internal fields must not be accessed directly.
+  Note, however, that `Aja.OrdMap` should be considered an opaque type: its struct internal fields
+  must not be accessed directly (even if not enforced by dialyzer because of pattern-matching).
 
   As discussed in the previous section, [`ord/1`](`Aja.ord/1`) and [`ord_size/1`](`Aja.ord_size/1`) makes it
   possible to pattern match on keys as well as check the type and size.
@@ -195,8 +195,15 @@ defmodule Aja.OrdMap do
            __ord_map__: %{optional(key) => [index | value]},
            __ord_vector__: RawVector.t({key, value})
          }
+
+  @typedoc """
+  The type of an `Aja.OrdMap` with keys of the type `key` and values of the type `value`.
+
+  It should be considered opaque even though it isn't enforced by dialyzer to enable pattern-matching.
+  """
   @type t(key, value) :: internals(key, value)
   @type t :: t(key, value)
+
   defstruct __ord_map__: %{}, __ord_vector__: RawVector.empty()
 
   @doc false

--- a/lib/vector.ex
+++ b/lib/vector.ex
@@ -100,8 +100,8 @@ defmodule Aja.Vector do
       iex> match?(%Aja.Vector{}, Aja.Vector.new())
       true
 
-  Note, however, than `Aja.Vector` is an [opaque type](https://hexdocs.pm/elixir/typespecs.html#user-defined-types):
-  its struct internal fields must not be accessed directly.
+  Note, however, that `Aja.Vector` should be considered an opaque type: its struct internal fields
+  must not be accessed directly (even if not enforced by dialyzer because of pattern-matching).
 
   As discussed in the previous section, [`vec/1`](`Aja.vec/1`) makes it
   possible to pattern match on size and elements as well as checking the type.
@@ -302,12 +302,18 @@ defmodule Aja.Vector do
   @type index :: integer
   @type value :: term
 
-  @opaque raw(value) :: Raw.t(value)
-  @type t(value) :: %__MODULE__{__vector__: raw(value)}
+  @typep internals(value) :: %__MODULE__{__vector__: Raw.t(value)}
+
+  @typedoc """
+  The type of an `Aja.Vector` with elements of the type `value`.
+
+  It should be considered opaque even though it isn't enforced by dialyzer to enable pattern-matching.
+  """
+  @type t(value) :: internals(value)
+  @type t :: t(value)
+
   @enforce_keys [:__vector__]
   defstruct [:__vector__]
-
-  @type t :: t(value)
 
   @empty_raw Raw.empty()
 

--- a/lib/vector/raw.ex
+++ b/lib/vector/raw.ex
@@ -47,7 +47,7 @@ defmodule Aja.Vector.Raw do
     end
   end
 
-  @spec empty :: t()
+  @spec empty :: t(none())
   def empty, do: @empty
 
   @type value :: term
@@ -56,7 +56,6 @@ defmodule Aja.Vector.Raw do
   @type shift :: non_neg_integer
   @type t(value) ::
           {0} | {size, tail_offset, shift | nil, Trie.t(value) | nil, Tail.t(value), value}
-  @type t() :: t(value)
 
   defmacro size(vector) do
     quote do
@@ -755,7 +754,7 @@ defmodule Aja.Vector.Raw do
   end
 
   def member?(empty_pattern(), _value), do: false
-  @spec any?(t()) :: boolean()
+  @spec any?(t(as_boolean(term))) :: boolean()
 
   def any?(small(size, tail, _first)) do
     Tail.partial_any?(tail, size)
@@ -780,7 +779,7 @@ defmodule Aja.Vector.Raw do
 
   def any?(empty_pattern(), _fun), do: false
 
-  @spec all?(t()) :: boolean()
+  @spec all?(t(as_boolean(term))) :: boolean()
 
   def all?(small(size, tail, _first)) do
     Tail.partial_all?(tail, size)


### PR DESCRIPTION
Alternative approach from https://github.com/sabiwara/aja/pull/4 to follow `OrdMap`'s implementation.

Rely on documentation to consider this type opaque, and stop using `@opaque` altogether since we might pattern-match on the internals using the `vec/1` or `ord/1` macros.

Thank you @MegaRedHand! 💜